### PR TITLE
Skip traces that cannot be parsed as filename:line

### DIFF
--- a/src/jit/p.lua
+++ b/src/jit/p.lua
@@ -156,11 +156,13 @@ local function prof_annotate(count1, samples)
     ms = math.max(ms, v)
     if pct >= prof_min then
       local file, line = k:match("^(.*):(%d+)$")
+      if not file then goto next end
       local fl = files[file]
       if not fl then fl = {}; files[file] = fl; files[#files+1] = file end
       line = tonumber(line)
       fl[line] = prof_raw and v or pct
     end
+    ::next::
   end
   sort(files)
   local fmtv, fmtn = " %3d%% | %s\n", "      | %s\n"


### PR DESCRIPTION
Running lwAFTR with profiling flags `-jp=fam1` finishes with a crash:

```
$ sudo ./snabb snsh -jp=fam1 -p lwaftr run -D 1 --conf lwaftr.conf --v4 83:00.0 --v6 83:00.1
stack traceback:
        core/main.lua:130: in function '__newindex'
        jit/p.lua:162: in function 'prof_annotate'
        jit/p.lua:236: in function 'stop'
        program/snsh/snsh.lua:78: in function 'run'
        core/main.lua:49: in function <core/main.lua:36>
        [C]: in function 'xpcall'
        core/main.lua:172: in main chunk
        [C]: at 0x0044e7a0
        [C]: in function 'pcall'
        core/startup.lua:3: in main chunk
        [C]: in function 'require'
        [string "require "core.startup""]:1: in main chunk
```

The crash is due to wrong parsing of a trace name. A trace name can be something like "[builtin:name]", while `src/jit/p.lua` expects to find a pattern like "%[builtin#(%d+)%]". On the same run I got the following TRACE with -jdump:

```
---- TRACE 36 start builtin:remove
0001  ISTYPE   0  12
0002  LEN      2   0
0003  ISNEP    1   0
0004  JMP      3 => 0012
0012  ISNUM    1  15
0013  KSHORT   3   1
0014  ISGT     3   1
0015  JMP      3 => 0030
0016  ISGT     1   2
0017  JMP      3 => 0030
0018  TGETR    3   0   1
```

jp.lua parses "builtin:remove" resulting in nil for the expected file name, which leads to a crash. The stackcall for the error goes like this:

```
jp.lua:prof_annotate ->
src/lj_profile:lj_profile.c:luaJIT_profile_dumpstack -> 
src/lj_debug.c:lj_debug_dumpstack -> 
src/lj_debug.c:debug_putchunkname
```

`debug_putchunkname` returns `[builtin:name]` when `pt->firstline` is `~(BCLine)0` (means "not a bytecode builtin"):

``` c
  if (pt->firstline == ~(BCLine)0) {
    lj_buf_putmem(sb, "[builtin:", 9);
    lj_buf_putstr(sb, name);
    lj_buf_putb(sb, ']');
    return 0;
```

This is in fact a LuaJIT bug (I replaced the fork with current LuaJIT's v2.1 and managed to reproduce the bug), but since I haven't managed to find a simpler case to reproduce it I think is worth to have it fixed at least in the Snabb fork.
